### PR TITLE
Overhaul LPC memory interface

### DIFF
--- a/modxo/data_store/data_store.c
+++ b/modxo/data_store/data_store.c
@@ -120,7 +120,7 @@ static void powerup(void)
 static void init(void)
 {
     powerup();
-    lpc_interface_add_io_handler(DATA_STORE_COMMAND_PORT, DATA_STORE_DATA_PORT, lpc_io_read, lpc_io_write);
+    lpc_interface_io_add_handler(DATA_STORE_COMMAND_PORT, DATA_STORE_DATA_PORT, lpc_io_read, lpc_io_write);
     //lpc_interface_add_mem_handler(DATA_STORE_ADDR_START, DATA_STORE_ADDR_END, lpc_mem_read, lpc_mem_write);
     msc_interface_add_handler(MEM_BUFFER_SIZE / MSC_DEFAULT_BLOCK_SIZE, MSC_DEFAULT_BLOCK_SIZE, "Mailbox", msc_read, msc_write);
 }

--- a/modxo/include/modxo/lpc_interface.h
+++ b/modxo/include/modxo/lpc_interface.h
@@ -24,10 +24,19 @@ typedef void (*lpc_mem_handler_cback)(uint32_t address, uint8_t *data);
 
 void lpc_interface_disable_onboard_flash(bool disable);
 void lpc_interface_start_sm(void);
-int lpc_interface_add_io_handler(uint16_t addr_start, uint16_t addr_end, lpc_io_handler_cback read_cback, lpc_io_handler_cback write_cback);
+
+// I/O Interface functions
+int lpc_interface_io_add_handler(uint16_t addr_start, uint16_t addr_end, lpc_io_handler_cback read_cback, lpc_io_handler_cback write_cback);
 bool lpc_interface_io_set_addr(unsigned int hdlr_idx, uint16_t addr_start, uint16_t addr_end);
-int lpc_interface_add_mem_handler(uint32_t addr_start, uint32_t addr_end, lpc_mem_handler_cback read_cback, lpc_mem_handler_cback write_cback);
-void lpc_interface_poll(void);
+
+// Memory interface functions
+void lpc_interface_mem_global_read_handler(uint8_t * read_buffer, uint32_t read_mask);
+void lpc_interface_mem_global_write_handler(uint8_t * write_buffer, uint32_t write_mask);
+
+// Map a buffer to one of 16 possible 1MB memory chunks at the one of the following paths: 0xFFX00000
+// Buffer should be of size N^2 and the mask should be N^2 - 1, for example an 8KB (2^13) buffer would have the mask 8192 - 1 = 0x1FFF
+bool lpc_interface_mem_set_read_handler(uint32_t address, uint8_t * read_buffer, uint32_t read_mask);
+bool lpc_interface_mem_set_write_handler(uint32_t address, uint8_t * write_buffer, uint32_t write_mask);
 
 extern MODXO_TASK lpc_interface_hdlr;
 #endif

--- a/modxo/lpc/lpc_comm.in
+++ b/modxo/lpc/lpc_comm.in
@@ -30,46 +30,46 @@
 .wrap_target
     pull
 wait_start:
-    wait 0 irq 7
-    wait 0 gpio LCLK_PIN
-    in pins,4
-    mov X, ISR
+    wait 0 irq 7                ; Wait for interrupt 7 to be 0
+    wait 0 gpio LCLK_PIN        ; Wait for LPC Clock to be 0
+    in pins,4                   ; Read a nibble into ISR
+    mov X, ISR                  ; Copy command from ISR into X
 check_start_again:
-    wait 1 gpio LCLK_PIN
-    mov ISR, null
-    jmp X-- wait_start
+    wait 1 gpio LCLK_PIN        ; Wait for LPC Clock to be 1
+    mov ISR, null               ; Clear the ISR
+    jmp X-- wait_start          ; If the command was anything other than 0b0000 (start command) then keep waiting
 
 wait_cmd:
-    wait 0 gpio LCLK_PIN [2]
-    in pins,4 
-    mov X, ISR
-    jmp X!=Y check_start_again
+    wait 0 gpio LCLK_PIN [2]    ; Wait for LPC Clock to be 0 then wait 2 cycles for bus turnaround
+    in pins,4                   ; Read a nibble into ISR
+    mov X, ISR                  ; Copy command from ISR into X
+    jmp X!=Y check_start_again  ; Check Cycly Type / Direction command against value pre-loaded into Y
     
-    irq set 7
-    mov X, OSR side 0
-    mov ISR, null
+    irq set 7                   ; Block all other SMs until done processing
+    mov X, OSR side 0           ; Pull number of nibbles to read out of TX FIFO
+    mov ISR, null               ; Clear ISR
 
 read_nibbles:
-    wait 0 gpio LCLK_PIN
-    in pins, 4 
-    set pins 5 
-    wait 1 gpio LCLK_PIN
-    jmp X-- read_nibbles
+    wait 0 gpio LCLK_PIN        ; Wait for LPC Clock to be 0
+    in pins, 4                  ; Read a nibble into ISR
+    set pins 5                  ; Insert a short-wait state
+    wait 1 gpio LCLK_PIN        ; Wait for LPC Clock to be 1
+    jmp X-- read_nibbles        ; Decrement X (nibbles remaining) and rerun read_nibbles
     
-    push
-    irq set 0 rel
-    set pindirs, 15
-    set X,3
-    pull
-    wait 0 gpio  LCLK_PIN
+    push                        ; Place incoming address + optional data byte into the RX FIFO
+    irq set 0 rel               ; Trigger interrupt 0, 1, 2, 3 based on what SM this is
+    set pindirs, 15             ; Set all pins to output
+    set X,3                     ; Output 3 nibbles, sync + optional data byte
+    pull                        ; Get data from RX fifo into OSR
+    wait 0 gpio  LCLK_PIN       ; Wait for LPC Clock to be 0
 repeat:
-    wait 1 gpio  LCLK_PIN
-    OUT pins,4
-    wait 0 gpio  LCLK_PIN
-    jmp X-- repeat
+    wait 1 gpio  LCLK_PIN       ; Wait for LPC Clock to be 1
+    OUT pins,4                  ; Output nibble from OSR
+    wait 0 gpio  LCLK_PIN       ; Wait for LPC Clock to be 0
+    jmp X-- repeat              ; Check if all data has been sent, else loop
    ;wait 1 gpio LCLK_PIN
-   set pindirs, 0b00000 [7]
-   irq clear 7 side 1
+   set pindirs, 0b00000 [7]     ; Set all pints to input
+   irq clear 7 side 1           ; Clear block for all other SMs
 .wrap
 % c-sdk {
 
@@ -81,7 +81,7 @@ repeat:
 
 void lpc_read_request_init(PIO pio, uint sm, uint offset, uint address_size, bool lframe_cancel) {
     pio_sm_set_enabled(pio, sm, false);
-    pio_sm_config c =lpc_read_request_program_get_default_config(offset);
+    pio_sm_config c = lpc_read_request_program_get_default_config(offset);
   
     sm_config_set_in_shift(
         &c,

--- a/modxo/modxo.c
+++ b/modxo/modxo.c
@@ -65,8 +65,8 @@ static void read_handler(uint16_t address, uint8_t *data)
 
 static void modxo_ports_init(void)
 {
-    lpc_interface_add_io_handler(MODXO_REGISTER_CHIP_ID, MODXO_REGISTER_CHIP_ID, read_handler, NULL);
-    lpc_interface_add_io_handler(MODXO_REGISTER_VARIANT_ID, MODXO_REGISTER_VARIANT_ID, read_handler, NULL);
+    lpc_interface_io_add_handler(MODXO_REGISTER_CHIP_ID, MODXO_REGISTER_CHIP_ID, read_handler, NULL);
+    lpc_interface_io_add_handler(MODXO_REGISTER_VARIANT_ID, MODXO_REGISTER_VARIANT_ID, read_handler, NULL);
 }
 
 void modxo_poll_core1()
@@ -76,9 +76,6 @@ void modxo_poll_core1()
 
 void modxo_poll_core0()
 {
-#ifdef LPC_LOGGING
-    lpc_interface_poll();
-#endif
     RUN_MODXO_HANDLERS(core0_poll);
 }
 

--- a/modxo_modules/legacy_display/legacy_display.c
+++ b/modxo_modules/legacy_display/legacy_display.c
@@ -282,7 +282,7 @@ static void init()
     legacy_display_set_spi_mode(3);
     legacy_display_set_spi(0);
     
-    lpc_interface_add_io_handler(MODXO_REGISTER_LCD_COMMAND, MODXO_REGISTER_LCD_COMMAND + 1, NULL, write_handler);
+    lpc_interface_io_add_handler(MODXO_REGISTER_LCD_COMMAND, MODXO_REGISTER_LCD_COMMAND + 1, NULL, write_handler);
 }
 
 

--- a/modxo_modules/superio/LPC47M152.c
+++ b/modxo_modules/superio/LPC47M152.c
@@ -172,7 +172,7 @@ static void lpc47m152_init(void)
 {
     modxo_debug_sp_connected = superio_connected;
     
-    lpc47m152_regs.lpc_hdlr_idx = lpc_interface_add_io_handler(CONFIG_PORT_DEFAULT_ADDR, CONFIG_PORT_DEFAULT_ADDR + 1, lpc47m152_read_handler, lpc47m152_write_handler); // LPC47M152(superio) port emulation
+    lpc47m152_regs.lpc_hdlr_idx = lpc_interface_io_add_handler(CONFIG_PORT_DEFAULT_ADDR, CONFIG_PORT_DEFAULT_ADDR + 1, lpc47m152_read_handler, lpc47m152_write_handler); // LPC47M152(superio) port emulation
     powerup();
 }
 

--- a/modxo_modules/superio/uart_16550.c
+++ b/modxo_modules/superio/uart_16550.c
@@ -110,8 +110,8 @@ static void powerup(void)
 
 static void uart_16550_init(void)
 {
-    lpc_interface_add_io_handler(UART_1_ADDR_START, UART_1_ADDR_END, lpc_io_read, lpc_io_write); // 16550 Uart 1 port emulation
-    lpc_interface_add_io_handler(UART_2_ADDR_START, UART_2_ADDR_END, lpc_io_read, lpc_io_write); // 16550 Uart 2 port emulation
+    lpc_interface_io_add_handler(UART_1_ADDR_START, UART_1_ADDR_END, lpc_io_read, lpc_io_write); // 16550 Uart 1 port emulation
+    lpc_interface_io_add_handler(UART_2_ADDR_START, UART_2_ADDR_END, lpc_io_read, lpc_io_write); // 16550 Uart 2 port emulation
 }
 
 MODXO_TASK uart_16550_hdlr = {

--- a/modxo_modules/ws2812/ws2812.c
+++ b/modxo_modules/ws2812/ws2812.c
@@ -759,8 +759,8 @@ static void ws2812_init()
         }
     }
 
-    lpc_interface_add_io_handler(WS2812_COMMAND_PORT, WS2812_DATA_PORT, lpc_port_read, lpc_port_write);
-    lpc_interface_add_io_handler(MODXO_REGISTER_NVM_CONFIG_SEL, MODXO_REGISTER_NVM_CONFIG_SEL + 1, config_read_hdlr, config_write_hdlr);
+    lpc_interface_io_add_handler(WS2812_COMMAND_PORT, WS2812_DATA_PORT, lpc_port_read, lpc_port_write);
+    lpc_interface_io_add_handler(MODXO_REGISTER_NVM_CONFIG_SEL, MODXO_REGISTER_NVM_CONFIG_SEL + 1, config_read_hdlr, config_write_hdlr);
 
     ws2812_update_pixels();
 }


### PR DESCRIPTION
The new LPC memory handler is now completely branchless and can map up to 16 read and 16 write 1MB maps into the following address range `0xFFX00000`